### PR TITLE
reset result_control when loading championship

### DIFF
--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -3399,6 +3399,9 @@ int load_champ(int iSlot)
           pszDefaultNameEnd += 9;
         } while (iDriverLoop < numcars);
       }
+      for (int i = 0; i < numcars; i++) {
+        result_control[i] = 0;
+      }
       iHumanPlayerLoop = 0;
       if (players > 0)                        // HUMAN PLAYER SETUP: Configure human players and assign them to cars
       {


### PR DESCRIPTION
Without resetting `result_control`, the first human will be placed in the second team car on next load. The next load after places you back in the first team car, and so on.