### PR TITLE
fix building rendering

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -2038,11 +2038,11 @@ LABEL_393:
       pBuildingRenderCmd->nRenderPriority = 13;
       //fOffsetTmp1 = iBuildingValue;
       //LOWORD(iBuildingValue) = pVisibleBuildingsPtr->iBuildingIdx;
-      ++pVisibleBuildingsPtr;
       pBuildingRenderCmd->nChunkIdx = pVisibleBuildingsPtr->iBuildingIdx;
       //pBuildingRenderCmd->nChunkIdx = LOWORD(iBuildingValue);
       pBuildingRenderCmd->fZDepth = pVisibleBuildingsPtr->fDepth;
       //pBuildingRenderCmd->fZDepth = fOffsetTmp1;
+      ++pVisibleBuildingsPtr;
       ++pBuildingRenderCmd;
       iBuildingNext = pVisibleBuildingsPtr->iBuildingIdx;
       num_bits = iBuildingCmdIndex + 1;


### PR DESCRIPTION
Just a bug in the conversion from the decompiled output. Previously it would cause the next building/sign to be rendered as if it were the current one, thus the closest sign would disappear (easily tested with the signs at the end of the front straight on track 15).