### PR TITLE
Multi nic hang

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1126,6 +1126,7 @@ static void print_usage(FILE *f, const char *argv0)
   fprintf(f, " -h, --help             show this help message and exit\n");
   fprintf(f, " --whiplash-root DIR    specify Whiplash data directory\n");
   fprintf(f, " --midi-root DIR        specify midi data directory\n");
+  fprintf(f, " --local-ip IP          local IPv4 address to advertise for multiplayer\n");
   fprintf(f, " --port N               UDP port to bind (default: %d)\n", ROLLER_DEFAULT_PORT);
   fprintf(f, " --peer IP:PORT         pre-configure a peer for direct connection\n");
   fprintf(f, " --net-slot N           network slot index; use -1 to join as client\n");
@@ -1169,6 +1170,14 @@ int main(int argc, const char **argv, const char **envp)
         consumed = 2;
       } else {
         fprintf(stderr, "ERROR: '--midi-root' needs an argument\n");
+        return 1;
+      }
+    } else if (strcmp(argv[i], "--local-ip") == 0) {
+      if (i + 1 < argc) {
+        ROLLERCommsSetLocalIP(argv[i + 1]);
+        consumed = 2;
+      } else {
+        fprintf(stderr, "ERROR: '--local-ip' needs an argument\n");
         return 1;
       }
     } else if (strcmp(argv[i], "--port") == 0) {

--- a/PROJECTS/ROLLER/control.c
+++ b/PROJECTS/ROLLER/control.c
@@ -3742,7 +3742,10 @@ void checkplacement(tCar *pCar)
         initcarview(ViewType[0], 0);
         stopallsamples();
       }
-      if ((Car[ViewType[1]].byLives & 0x80u) != 0) {
+      
+      if (ViewType[1] >= 0 && ViewType[1] < numcars //ViewType[1] is intentionally -1 when single player
+        && (Car[ViewType[1]].byLives & 0x80u) != 0) {
+
         for (ViewType[1] = 0; !human_control[ViewType[1]] || (Car[ViewType[1]].byLives & 0x80u) != 0; ++ViewType[1])
           ;
         initcarview(ViewType[1], 0);

--- a/PROJECTS/ROLLER/frontend_network.c
+++ b/PROJECTS/ROLLER/frontend_network.c
@@ -296,11 +296,16 @@ LABEL_83:
     if (wConsoleNode == master)               // Master node waits for all client records, then broadcasts seed
     {
       int iLastRecordWaitLog = -1000;
+      int iLastStartResend = -1000;
       while (received_records < network_on) {
         if (frames - iLastRecordWaitLog >= 36) {
           iLastRecordWaitLog = frames;
           SDL_Log("[NET-START] master waiting for records received=%d expected=%d",
                   received_records, network_on);
+        }
+        if (frames - iLastStartResend >= 36) {
+          iLastStartResend = frames;
+          TransmitInit();
         }
         CheckNewNodes();
         UpdateSDL();

--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -5904,6 +5904,22 @@ void show_received_mesage()
 }
 
 //-------------------------------------------------------------------------------------------------
+static void AddCachedNetworkSlotNodes(int iSlot)
+{
+  if (iSlot < 0 || iSlot >= 4)
+    return;
+
+  int iCachedNodes = gamers_playing[iSlot];
+  if (iCachedNodes <= 0 || iCachedNodes > 16)
+    return;
+
+  for (int i = 0; i < iCachedNodes; i++) {
+    ROLLERCommsAddNode(&gamers_address[iSlot][i]);
+  }
+  ROLLERCommsSortNodes();
+}
+
+//-------------------------------------------------------------------------------------------------
 //0005EFB0
 int select_netslot()
 {
@@ -6193,6 +6209,7 @@ int select_netslot()
           }
         } else if (uiKeyCode <= 0xD) {                                       // Enter key - select current slot if available
           if ((unsigned int)gamers_playing[iCurrentSlot] < 16) {
+            AddCachedNetworkSlotNodes(iCurrentSlot);
             iExitFlag = -1;
             iReturnValue = iCurrentSlot + 1;
           }

--- a/PROJECTS/ROLLER/network.c
+++ b/PROJECTS/ROLLER/network.c
@@ -108,6 +108,32 @@ static void LogDiscoveryAddress(const char *szMessage, const int32 pAddress[4])
 
 //-------------------------------------------------------------------------------------------------
 
+static int GetLastPacketAddress(int32 pAddress[4])
+{
+  tROLLERNetAddr netAddr;
+  if (!pAddress)
+    return 0;
+
+  ROLLERCommsGetLastPacketAddr(&netAddr);
+  netAddr.unPadding = 0;
+  netAddr.ullReserved = 0;
+  memcpy(pAddress, &netAddr, sizeof(netAddr));
+  return !IsInvalidPacketAddress(pAddress);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+static void UpdateDiscoveryTransport(const int32 pAddress[4], const int32 pTransportAddress[4])
+{
+  if (!pAddress || !pTransportAddress)
+    return;
+  if (IsInvalidPacketAddress(pTransportAddress) || IsLocalPacketAddress(pTransportAddress))
+    return;
+  ROLLERCommsUpdateNodeTransportAddr(pAddress, pTransportAddress);
+}
+
+//-------------------------------------------------------------------------------------------------
+
 static void PulseLobbyDiscovery(void)
 {
   if (!frontend_on || !network_on || time_to_start || !master)
@@ -1123,6 +1149,8 @@ int TransmitInit()
 
   iSuccess = -1;
   if (network_on) {
+    ROLLERCommsGetNetworkAddr(address);
+    NormalizePacketAddress(address);
     header.byConsoleNode = player1_car;
     header.uiId = PACKET_ID_TRANSMIT_INIT;
     initPacket.iTrackLoad = TrackLoad;
@@ -1269,6 +1297,7 @@ void CheckNewNodes()
   tPlayerInfoPacket playerInfoPacket; // [esp+118h] [ebp-74h] BYREF
   tRecordPacket recordPacket; // [esp+140h] [ebp-4Ch] BYREF
   tSyncHeader syncHeader; // [esp+150h] [ebp-3Ch] BYREF
+  int32 packetTransportAddress[4];
   void *pPacket2; // [esp+15Ch] [ebp-30h] BYREF
   int iMaxGamerIndex; // [esp+160h] [ebp-2Ch]
   int *pTestSeed; // [esp+164h] [ebp-28h]
@@ -1286,6 +1315,8 @@ void CheckNewNodes()
         transmitInitPacket.iNetworkSlot = 0;
         ROLLERCommsGetBlock(pPacket2, &transmitInitPacket, sizeof(tTransmitInitPacket));
         NormalizePacketAddress(transmitInitPacket.address);
+        memset(packetTransportAddress, 0, sizeof(packetTransportAddress));
+        GetLastPacketAddress(packetTransportAddress);
         if (IsInvalidPacketAddress(transmitInitPacket.address)) {
           LogDiscoveryAddress("ignored invalid", transmitInitPacket.address);
           goto LABEL_40;
@@ -1294,6 +1325,10 @@ void CheckNewNodes()
           LogDiscoveryAddress("ignored self", transmitInitPacket.address);
           goto LABEL_40;
         }
+        ROLLERCommsUpdateLocalAddrForPeer(transmitInitPacket.address);
+        ROLLERCommsGetNetworkAddr(address);
+        NormalizePacketAddress(address);
+        UpdateDiscoveryTransport(transmitInitPacket.address, packetTransportAddress);
         if (network_slot >= 0)                // Process init packet when we are already connected (network_slot >= 0)
         {
           if (transmitInitPacket.iNetworkSlot < 0 && !I_Quit) {

--- a/PROJECTS/ROLLER/rollercomms.c
+++ b/PROJECTS/ROLLER/rollercomms.c
@@ -28,9 +28,16 @@
 typedef struct
 {
   tROLLERNetAddr address;
+  tROLLERNetAddr transportAddress;
   SOCKET socket;
   bool bActive;
 } tNodeInfo;
+
+typedef struct
+{
+  tROLLERNetAddr address;
+  tROLLERNetAddr transportAddress;
+} tPendingTransport;
 
 static struct
 {
@@ -46,6 +53,7 @@ static struct
   uint8 receiveBuffer[ROLLER_MAX_PACKET_SIZE];
   int iReceiveSize;
   void *pCurrentPacketData;
+  tROLLERNetAddr lastPacketAddress;
 
 } g_commsState;
 
@@ -54,6 +62,8 @@ static uint16_t s_unLocalPort = ROLLER_DEFAULT_PORT;
 static bool s_bHasPeer = false;
 static tROLLERNetAddr s_peerAddr;
 static uint32_t s_uiLocalIPOverride = 0; // 0 = auto-detect
+static tPendingTransport s_pendingTransports[ROLLER_MAX_NODES];
+static int s_iPendingTransports = 0;
 
 //-------------------------------------------------------------------------------------------------
 
@@ -115,6 +125,111 @@ static uint32_t DetectLocalIPv4(void)
   struct in_addr addr;
   inet_pton(AF_INET, iface.szIP, &addr);
   return addr.s_addr;
+}
+
+static uint32_t DetectRouteLocalIPv4(uint32_t uiRemoteIP, uint16_t unRemotePort)
+{
+  if (uiRemoteIP == 0)
+    return 0;
+
+  SOCKET routeSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (routeSocket == INVALID_SOCKET)
+    return 0;
+
+  struct sockaddr_in remoteAddr;
+  memset(&remoteAddr, 0, sizeof(remoteAddr));
+  remoteAddr.sin_family = AF_INET;
+  remoteAddr.sin_addr.s_addr = uiRemoteIP;
+  remoteAddr.sin_port = htons(unRemotePort ? unRemotePort : ROLLER_DEFAULT_PORT);
+
+  uint32_t uiLocalIP = 0;
+  if (connect(routeSocket, (struct sockaddr *)&remoteAddr, sizeof(remoteAddr)) != SOCKET_ERROR) {
+    struct sockaddr_in localAddr;
+    socklen_t localLen = sizeof(localAddr);
+    memset(&localAddr, 0, sizeof(localAddr));
+    if (getsockname(routeSocket, (struct sockaddr *)&localAddr, &localLen) != SOCKET_ERROR) {
+      uiLocalIP = localAddr.sin_addr.s_addr;
+    }
+  }
+
+  closesocket(routeSocket);
+  return uiLocalIP;
+}
+
+static uint32_t GetConfiguredLocalIPv4(void)
+{
+  if (s_uiLocalIPOverride)
+    return s_uiLocalIPOverride;
+  if (s_bHasPeer && s_peerAddr.uiIPAddress == htonl(INADDR_LOOPBACK))
+    return htonl(INADDR_LOOPBACK);
+  if (s_bHasPeer) {
+    uint32_t uiRouteIP = DetectRouteLocalIPv4(s_peerAddr.uiIPAddress, s_peerAddr.unPort);
+    if (uiRouteIP)
+      return uiRouteIP;
+  }
+  return DetectLocalIPv4();
+}
+
+static void ApplyLocalAddressIPv4(uint32_t uiLocalIP, const char *szReason,
+                                  const tROLLERNetAddr *pPeerAddress)
+{
+  if (!g_commsState.bInitialized || uiLocalIP == 0)
+    return;
+
+  tROLLERNetAddr newAddress;
+  memset(&newAddress, 0, sizeof(newAddress));
+  newAddress.uiIPAddress = uiLocalIP;
+  newAddress.unPort = s_unLocalPort;
+
+  if (memcmp(&g_commsState.myAddress, &newAddress, sizeof(newAddress)) == 0)
+    return;
+
+  tROLLERNetAddr oldAddress = g_commsState.myAddress;
+  g_commsState.myAddress = newAddress;
+  if (g_commsState.iActiveNodes == 0) {
+    g_commsState.iActiveNodes = 1;
+  }
+
+  int iSelfNode = g_commsState.iConsoleNode;
+  if (iSelfNode < 0 || iSelfNode >= g_commsState.iActiveNodes ||
+      memcmp(&g_commsState.nodes[iSelfNode].address, &oldAddress, sizeof(oldAddress)) != 0) {
+    iSelfNode = -1;
+    for (int i = 0; i < g_commsState.iActiveNodes; i++) {
+      if (memcmp(&g_commsState.nodes[i].address, &oldAddress, sizeof(oldAddress)) == 0) {
+        iSelfNode = i;
+        break;
+      }
+    }
+  }
+
+  if (iSelfNode < 0)
+    iSelfNode = 0;
+
+  g_commsState.nodes[iSelfNode].address = newAddress;
+  g_commsState.nodes[iSelfNode].transportAddress = newAddress;
+  g_commsState.nodes[iSelfNode].bActive = true;
+  g_commsState.iConsoleNode = iSelfNode;
+
+  char szAddr[32];
+  ROLLERCommsFormatAddr(&newAddress, szAddr, sizeof(szAddr));
+  if (pPeerAddress) {
+    char szPeer[32];
+    ROLLERCommsFormatAddr(pPeerAddress, szPeer, sizeof(szPeer));
+    SDL_Log("[NET-DISCOVERY] selected local address %s for %s via %s",
+            szAddr, szPeer, szReason ? szReason : "route");
+  } else {
+    SDL_Log("[NET-DISCOVERY] selected local address %s", szAddr);
+  }
+
+  ROLLERCommsSortNodes();
+}
+
+static void ApplyLocalIPOverrideIfIdle(void)
+{
+  if (!g_commsState.bInitialized || g_commsState.iActiveNodes > 1)
+    return;
+
+  ApplyLocalAddressIPv4(GetConfiguredLocalIPv4(), "configuration", NULL);
 }
 
 static int InitializeSockets(void)
@@ -199,11 +314,16 @@ void ROLLERCommsSetLocalIP(const char *szIP)
 {
   if (!szIP || szIP[0] == '\0') {
     s_uiLocalIPOverride = 0;
+    ApplyLocalIPOverrideIfIdle();
     return;
   }
   struct in_addr addr;
-  if (inet_pton(AF_INET, szIP, &addr) == 1)
+  if (inet_pton(AF_INET, szIP, &addr) == 1) {
     s_uiLocalIPOverride = addr.s_addr;
+    ApplyLocalIPOverrideIfIdle();
+  } else {
+    printf("ROLLERCommsSetLocalIP: invalid IP address '%s'\n", szIP);
+  }
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -220,6 +340,30 @@ void ROLLERCommsSetPeer(const char *szIP, uint16_t unPort)
   s_peerAddr.unPadding = 0;
   s_peerAddr.ullReserved = 0;
   s_bHasPeer = true;
+  if (g_commsState.bInitialized && !s_uiLocalIPOverride) {
+    uint32_t uiRouteIP = DetectRouteLocalIPv4(s_peerAddr.uiIPAddress, s_peerAddr.unPort);
+    ApplyLocalAddressIPv4(uiRouteIP, "peer", &s_peerAddr);
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void ROLLERCommsUpdateLocalAddrForPeer(const void *pPeerAddress)
+{
+  if (!g_commsState.bInitialized || s_uiLocalIPOverride || !pPeerAddress)
+    return;
+
+  tROLLERNetAddr peerAddress;
+  memset(&peerAddress, 0, sizeof(peerAddress));
+  memcpy(&peerAddress, pPeerAddress, sizeof(peerAddress));
+  peerAddress.unPadding = 0;
+  peerAddress.ullReserved = 0;
+
+  if (peerAddress.uiIPAddress == 0 || peerAddress.unPort == 0)
+    return;
+
+  uint32_t uiRouteIP = DetectRouteLocalIPv4(peerAddress.uiIPAddress, peerAddress.unPort);
+  ApplyLocalAddressIPv4(uiRouteIP, "route", &peerAddress);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -235,6 +379,7 @@ int ROLLERCommsInitSystem(unsigned int uiMaxPackets)
   }
 
   memset(&g_commsState, 0, sizeof(g_commsState));
+  s_iPendingTransports = 0;
   g_commsState.listenSocket = INVALID_SOCKET;
 
   g_commsState.listenSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -270,13 +415,7 @@ int ROLLERCommsInitSystem(unsigned int uiMaxPackets)
     return 0;
   }
 
-  if (s_uiLocalIPOverride) {
-    g_commsState.myAddress.uiIPAddress = s_uiLocalIPOverride;
-  } else {
-    g_commsState.myAddress.uiIPAddress = DetectLocalIPv4();
-    if (s_bHasPeer && s_peerAddr.uiIPAddress == htonl(INADDR_LOOPBACK))
-      g_commsState.myAddress.uiIPAddress = htonl(INADDR_LOOPBACK);
-  }
+  g_commsState.myAddress.uiIPAddress = GetConfiguredLocalIPv4();
   g_commsState.myAddress.unPort = s_unLocalPort;
   g_commsState.myAddress.unPadding = 0;
   g_commsState.myAddress.ullReserved = 0;
@@ -298,6 +437,47 @@ int ROLLERCommsInitSystem(unsigned int uiMaxPackets)
   return 1;
 }
 
+static void RememberPendingTransport(const tROLLERNetAddr *pAddress,
+                                     const tROLLERNetAddr *pTransportAddress)
+{
+  if (!pAddress || !pTransportAddress)
+    return;
+  if (memcmp(pAddress, pTransportAddress, sizeof(tROLLERNetAddr)) == 0)
+    return;
+
+  for (int i = 0; i < s_iPendingTransports; i++) {
+    if (memcmp(&s_pendingTransports[i].address, pAddress, sizeof(tROLLERNetAddr)) == 0) {
+      s_pendingTransports[i].transportAddress = *pTransportAddress;
+      return;
+    }
+  }
+
+  if (s_iPendingTransports >= ROLLER_MAX_NODES)
+    return;
+
+  s_pendingTransports[s_iPendingTransports].address = *pAddress;
+  s_pendingTransports[s_iPendingTransports].transportAddress = *pTransportAddress;
+  s_iPendingTransports++;
+}
+
+static void ApplyPendingTransport(tNodeInfo *pNode)
+{
+  if (!pNode)
+    return;
+
+  for (int i = 0; i < s_iPendingTransports; i++) {
+    if (memcmp(&s_pendingTransports[i].address, &pNode->address, sizeof(tROLLERNetAddr)) == 0) {
+      pNode->transportAddress = s_pendingTransports[i].transportAddress;
+      char szAddress[32];
+      char szTransport[32];
+      ROLLERCommsFormatAddr(&pNode->address, szAddress, sizeof(szAddress));
+      ROLLERCommsFormatAddr(&pNode->transportAddress, szTransport, sizeof(szTransport));
+      SDL_Log("[NET-DISCOVERY] route %s via %s", szAddress, szTransport);
+      return;
+    }
+  }
+}
+
 //-------------------------------------------------------------------------------------------------
 
 void ROLLERCommsUnInitSystem()
@@ -313,6 +493,7 @@ void ROLLERCommsUnInitSystem()
 
   CleanupSockets();
   memset(&g_commsState, 0, sizeof(g_commsState));
+  s_iPendingTransports = 0;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -356,8 +537,8 @@ int ROLLERCommsSendData(
   if (!BuildPacket(packetBuffer, &iTotalSize, pHeader, iHeaderSize, pData, iDataSize)) {
     return 0;
   }
-  return SendPacketToIPv4(g_commsState.nodes[iDestNode].address.uiIPAddress,
-                          g_commsState.nodes[iDestNode].address.unPort,
+  return SendPacketToIPv4(g_commsState.nodes[iDestNode].transportAddress.uiIPAddress,
+                          g_commsState.nodes[iDestNode].transportAddress.unPort,
                           packetBuffer,
                           iTotalSize);
 }
@@ -413,6 +594,10 @@ int ROLLERCommsGetHeader(void *pHeaderOut, int iHeaderSize, void **ppDataOut)
   if (iBytesReceived <= 0) {
     return 0; // No data available
   }
+
+  memset(&g_commsState.lastPacketAddress, 0, sizeof(g_commsState.lastPacketAddress));
+  g_commsState.lastPacketAddress.uiIPAddress = fromAddr.sin_addr.s_addr;
+  g_commsState.lastPacketAddress.unPort = ntohs(fromAddr.sin_port);
 
   if (iBytesReceived < iHeaderSize) {
     return 0; // Packet too small
@@ -497,10 +682,53 @@ int ROLLERCommsAddNode(const void *pAddress)
 
   int iNodeIdx = g_commsState.iActiveNodes;
   memcpy(&g_commsState.nodes[iNodeIdx].address, &address, sizeof(tROLLERNetAddr));
+  memcpy(&g_commsState.nodes[iNodeIdx].transportAddress, &address, sizeof(tROLLERNetAddr));
+  ApplyPendingTransport(&g_commsState.nodes[iNodeIdx]);
   g_commsState.nodes[iNodeIdx].bActive = true;
   g_commsState.iActiveNodes++;
 
   return 0;  // Success
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void ROLLERCommsUpdateNodeTransportAddr(const void *pAddress, const void *pTransportAddress)
+{
+  tROLLERNetAddr address;
+  tROLLERNetAddr transportAddress;
+
+  if (!g_commsState.bInitialized || !pAddress || !pTransportAddress)
+    return;
+
+  memset(&address, 0, sizeof(address));
+  memcpy(&address, pAddress, sizeof(address));
+  address.unPadding = 0;
+  address.ullReserved = 0;
+
+  memset(&transportAddress, 0, sizeof(transportAddress));
+  memcpy(&transportAddress, pTransportAddress, sizeof(transportAddress));
+  transportAddress.unPadding = 0;
+  transportAddress.ullReserved = 0;
+
+  if (transportAddress.uiIPAddress == 0 || transportAddress.unPort == 0)
+    return;
+
+  for (int i = 0; i < g_commsState.iActiveNodes; i++) {
+    if (memcmp(&g_commsState.nodes[i].address, &address, sizeof(address)) == 0) {
+      if (memcmp(&g_commsState.nodes[i].transportAddress, &transportAddress,
+                 sizeof(transportAddress)) != 0) {
+        char szAddress[32];
+        char szTransport[32];
+        ROLLERCommsFormatAddr(&address, szAddress, sizeof(szAddress));
+        ROLLERCommsFormatAddr(&transportAddress, szTransport, sizeof(szTransport));
+        SDL_Log("[NET-DISCOVERY] route %s via %s", szAddress, szTransport);
+        g_commsState.nodes[i].transportAddress = transportAddress;
+      }
+      return;
+    }
+  }
+
+  RememberPendingTransport(&address, &transportAddress);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -566,10 +794,20 @@ void ROLLERCommsSortNodes(void)
          g_commsState.iActiveNodes, g_commsState.iConsoleNode);
   for (int i = 0; i < g_commsState.iActiveNodes; i++) {
     char szIP[INET_ADDRSTRLEN];
+    char szTransport[32];
     inet_ntop(AF_INET, &g_commsState.nodes[i].address.uiIPAddress, szIP, sizeof(szIP));
-    SDL_Log("[NET]   node[%d]: %s:%u%s\n", i, szIP,
-           (unsigned)g_commsState.nodes[i].address.unPort,
-           i == g_commsState.iConsoleNode ? " <-- self" : "");
+    if (memcmp(&g_commsState.nodes[i].address, &g_commsState.nodes[i].transportAddress,
+               sizeof(tROLLERNetAddr)) != 0) {
+      ROLLERCommsFormatAddr(&g_commsState.nodes[i].transportAddress,
+                            szTransport, sizeof(szTransport));
+      SDL_Log("[NET]   node[%d]: %s:%u via %s%s\n", i, szIP,
+             (unsigned)g_commsState.nodes[i].address.unPort, szTransport,
+             i == g_commsState.iConsoleNode ? " <-- self" : "");
+    } else {
+      SDL_Log("[NET]   node[%d]: %s:%u%s\n", i, szIP,
+             (unsigned)g_commsState.nodes[i].address.unPort,
+             i == g_commsState.iConsoleNode ? " <-- self" : "");
+    }
   }
 }
 
@@ -626,6 +864,15 @@ void ROLLERCommsGetNetworkAddr(int *pAddressOut)
 
 //-------------------------------------------------------------------------------------------------
 
+void ROLLERCommsGetLastPacketAddr(tROLLERNetAddr *pAddressOut)
+{
+  if (pAddressOut) {
+    memcpy(pAddressOut, &g_commsState.lastPacketAddress, sizeof(tROLLERNetAddr));
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
+
 int ROLLERCommsNetAddrToNode(const int *pAddress)
 {
   // Find node with matching address
@@ -647,11 +894,8 @@ void ROLLERCommsGetLocalAddrStr(char *szBuf, int iBufLen)
   if (g_commsState.bInitialized) {
     uiIP   = g_commsState.myAddress.uiIPAddress;
     unPort = g_commsState.myAddress.unPort;
-  } else if (s_uiLocalIPOverride) {
-    uiIP   = s_uiLocalIPOverride;
-    unPort = s_unLocalPort;
   } else {
-    uiIP   = DetectLocalIPv4();
+    uiIP   = GetConfiguredLocalIPv4();
     unPort = s_unLocalPort;
   }
   char szIP[INET_ADDRSTRLEN];
@@ -674,7 +918,16 @@ void ROLLERCommsGetNodeAddrStr(int iNode, char *szBuf, int iBufLen)
   struct in_addr addr;
   addr.s_addr = g_commsState.nodes[iNode].address.uiIPAddress;
   inet_ntop(AF_INET, &addr, szIP, sizeof(szIP));
-  snprintf(szBuf, iBufLen, "%s:%u", szIP, (unsigned)g_commsState.nodes[iNode].address.unPort);
+  if (memcmp(&g_commsState.nodes[iNode].address, &g_commsState.nodes[iNode].transportAddress,
+             sizeof(tROLLERNetAddr)) != 0) {
+    char szTransport[32];
+    ROLLERCommsFormatAddr(&g_commsState.nodes[iNode].transportAddress,
+                          szTransport, sizeof(szTransport));
+    snprintf(szBuf, iBufLen, "%s:%u via %s", szIP,
+             (unsigned)g_commsState.nodes[iNode].address.unPort, szTransport);
+  } else {
+    snprintf(szBuf, iBufLen, "%s:%u", szIP, (unsigned)g_commsState.nodes[iNode].address.unPort);
+  }
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/rollercomms.h
+++ b/PROJECTS/ROLLER/rollercomms.h
@@ -36,17 +36,20 @@ int ROLLERCommsInitSystem(unsigned int uiMaxPackets);
 void ROLLERCommsUnInitSystem(void);
 void ROLLERCommsSetType(int iType); // 0 = IPX emulation, 1 = Serial emulation
 int ROLLERCommsGetType(void);
+void ROLLERCommsUpdateLocalAddrForPeer(const void *pPeerAddress);
 
 // Node management
 int ROLLERCommsGetActiveNodes(void);
 int ROLLERCommsGetConsoleNode(void);
 int ROLLERCommsAddNode(const void *pAddress);
+void ROLLERCommsUpdateNodeTransportAddr(const void *pAddress, const void *pTransportAddress);
 int ROLLERCommsDeleteNode(int iNodeIdx);
 void ROLLERCommsSortNodes(void);
 int ROLLERCommsNetAddrToNode(const int *pAddress);
 
 // Address
 void ROLLERCommsGetNetworkAddr(int *pAddressOut);
+void ROLLERCommsGetLastPacketAddr(tROLLERNetAddr *pAddressOut);
 void ROLLERCommsGetLocalAddrStr(char *szBuf, int iBufLen);
 void ROLLERCommsGetNodeAddrStr(int iNode, char *szBuf, int iBufLen);
 void ROLLERCommsFormatAddr(const tROLLERNetAddr *pAddress, char *szBuf, int iBufLen);

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,11 @@ pub fn build(b: *std.Build) void {
         &.{ "-fwrapv", "-fno-omit-frame-pointer" }
     else
         &.{"-fwrapv"};
+    const python_checks = b.option(
+        bool,
+        "python-checks",
+        "Run optional Python-based seam checks",
+    ) orelse false;
 
     const exe_mod = b.createModule(.{
         .target = target,
@@ -116,11 +121,13 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(exe);
 
-    const scene_render_seam_check = b.addSystemCommand(&.{
-        "python3",
-        "tests/scene_render_seam_check.py",
-    });
-    exe.step.dependOn(&scene_render_seam_check.step);
+    if (python_checks) {
+        const scene_render_seam_check = b.addSystemCommand(&.{
+            pythonExe(),
+            "tests/scene_render_seam_check.py",
+        });
+        exe.step.dependOn(&scene_render_seam_check.step);
+    }
 
     configureDependencies(b, exe, target, optimize);
 
@@ -164,7 +171,7 @@ pub fn build(b: *std.Build) void {
     });
     run_step.dependOn(&wildmidi_config_install.step);
 
-    configureRenderQueue3DTests(b, target, optimize, c_flags);
+    configureRenderQueue3DTests(b, target, optimize, c_flags, python_checks);
 
     // Snapshot regression harness: drive the snapshot binary serially across
     // every configured intro replay, writing PNGs straight into the
@@ -181,6 +188,7 @@ fn configureRenderQueue3DTests(
     target: ResolvedTarget,
     optimize: OptimizeMode,
     c_flags: []const []const u8,
+    python_checks: bool,
 ) void {
     const test_mod = b.createModule(.{
         .target = target,
@@ -208,19 +216,21 @@ fn configureRenderQueue3DTests(
     });
     const run_unit = b.addRunArtifact(test_exe);
 
-    const seam_check = b.addSystemCommand(&.{
-        "python3",
-        "tools/check_render_queue_3d_seams.py",
-    });
-
     const render_queue_tests = b.step(
         "test-render-queue-3d",
-        "Run render_queue_3d sort/mapping tests and seam checks",
+        "Run render_queue_3d sort/mapping tests",
     );
     render_queue_tests.dependOn(&run_unit.step);
-    render_queue_tests.dependOn(&seam_check.step);
 
-    const test_step = b.step("test", "Run focused unit and seam tests");
+    if (python_checks) {
+        const seam_check = b.addSystemCommand(&.{
+            pythonExe(),
+            "tools/check_render_queue_3d_seams.py",
+        });
+        render_queue_tests.dependOn(&seam_check.step);
+    }
+
+    const test_step = b.step("test", "Run focused unit tests and optional seam checks");
     test_step.dependOn(render_queue_tests);
 }
 
@@ -421,8 +431,13 @@ fn configureDependencies(b: *Build, exe: *Compile, target: ResolvedTarget, optim
     cflags_step.dependOn(&cflags.step);
 }
 
+fn pythonExe() []const u8 {
+    return if (host_builtin.os.tag == .windows) "python" else "python3";
+}
+
 const compile_flagz = @import("compile_flagz");
 
+const host_builtin = @import("builtin");
 const std = @import("std");
 const ArrayList = std.ArrayListUnmanaged;
 const Build = std.Build;


### PR DESCRIPTION
## Summary

Fixes multiplayer hangs on race start when one machine has multiple network interfaces.

The networking layer now separates a node’s advertised game address from the transport address packets actually arrive from, so discovery and later race-start messages can route back through the reachable interface. It also improves local IP selection by choosing the address the OS would use to reach a discovered peer, while still allowing `--local-ip` as an explicit override.

## Changes

- Add `--local-ip` for manually choosing the advertised multiplayer IPv4 address.
- Track each node’s advertised address separately from its UDP transport address.
- Learn transport routes from incoming discovery packets.
- Update local advertised IP based on the route to discovered peers on multi-NIC hosts.
- Seed cached lobby nodes when selecting a network slot.
- Resend start/init packets while the master waits for client lap records.

## Testing

- Verified `zig build`.
- Verified `zig build test`.
- Tested Windows/Linux multiplayer across a multi-NIC host; discovery, record exchange, seed broadcast, and race start now complete successfully.
